### PR TITLE
Refactor into smaller API footprint

### DIFF
--- a/command.go
+++ b/command.go
@@ -1,6 +1,7 @@
 package drouter
 
 import (
+	"github.com/NyanKiyoshi/disgord-plugin-router/internal/stringset"
 	"regexp"
 	"strings"
 )
@@ -10,7 +11,7 @@ type matcherFunc func(input string) bool
 // Command defines the structure of a plugin sub-command.
 type Command struct {
 	// Names lists the different aliases of the sub-command.
-	Names StringSet
+	Names stringset.StringSet
 
 	// MatchFunc is called whenever a new message
 	// (starting with the correct prefix) is received by the plugin
@@ -29,6 +30,13 @@ type Command struct {
 
 	// LongHelp Contains the long descriptive command documentation.
 	LongHelp string
+}
+
+// newCommand creates and initialize a new command object.
+func newCommand(names ...string) Command {
+	return Command{
+		Names: stringset.NewStringSet(names...),
+	}
 }
 
 // Match sets the matching function from a given function.

--- a/command.go
+++ b/command.go
@@ -8,8 +8,8 @@ import (
 
 type matcherFunc func(input string) bool
 
-// Command defines the structure of a plugin sub-command.
-type Command struct {
+// command defines the structure of a plugin sub-command.
+type command struct {
 	// Names lists the different aliases of the sub-command.
 	Names stringset.StringSet
 
@@ -33,20 +33,20 @@ type Command struct {
 }
 
 // newCommand creates and initialize a new command object.
-func newCommand(names ...string) Command {
-	return Command{
+func newCommand(names ...string) command {
+	return command{
 		Names: stringset.NewStringSet(names...),
 	}
 }
 
 // Match sets the matching function from a given function.
-func (cmd *Command) Match(matcherFunc matcherFunc) *Command {
+func (cmd *command) Match(matcherFunc matcherFunc) *command {
 	cmd.MatchFunc = matcherFunc
 	return cmd
 }
 
 // MatchRE defines a matching function from a given regex.
-func (cmd *Command) MatchRE(regex string) *Command {
+func (cmd *command) MatchRE(regex string) *command {
 	matcher := regexp.MustCompile(regex)
 
 	cmd.MatchFunc = func(input string) bool {
@@ -58,14 +58,14 @@ func (cmd *Command) MatchRE(regex string) *Command {
 
 // Handler defines the function to invoke whenever the command
 // is being invoked.
-func (cmd *Command) Handler(callbackFunc callbackFunc) *Command {
+func (cmd *command) Handler(callbackFunc callbackFunc) *command {
 	cmd.HandlerFunc = callbackFunc
 	return cmd
 }
 
 // Use appends given callbacks to a command to call
 // whenever a command is being invoked.
-func (cmd *Command) Use(callbackFuncs ...callbackFunc) *Command {
+func (cmd *command) Use(callbackFuncs ...callbackFunc) *command {
 	cmd.Wrappers = append(cmd.Wrappers, callbackFuncs...)
 	return cmd
 }
@@ -73,7 +73,7 @@ func (cmd *Command) Use(callbackFuncs ...callbackFunc) *Command {
 // Help sets the help text of a command. The first line is
 // the short and straightforward documentation. The whole text
 // is the long and descriptive documentation.
-func (cmd *Command) Help(helpText string) *Command {
+func (cmd *command) Help(helpText string) *command {
 	if startPos := strings.Index(helpText, "\n"); startPos > -1 {
 		cmd.ShortHelp = helpText[:startPos]
 	} else {
@@ -86,6 +86,6 @@ func (cmd *Command) Help(helpText string) *Command {
 
 // IsMatching returns true if the command name exists or
 // if it matches the matching function, if provided.
-func (cmd *Command) IsMatching(targetCommand string) bool {
+func (cmd *command) IsMatching(targetCommand string) bool {
 	return cmd.Names.Contains(targetCommand) || (cmd.MatchFunc != nil && cmd.MatchFunc(targetCommand))
 }

--- a/command_test.go
+++ b/command_test.go
@@ -2,6 +2,7 @@ package drouter_test
 
 import (
 	"github.com/NyanKiyoshi/disgord-plugin-router"
+	"github.com/NyanKiyoshi/disgord-plugin-router/internal/stringset"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
@@ -12,7 +13,7 @@ func createDummyCommand(names ...string) *drouter.Command {
 	}
 
 	cmd := &drouter.Command{
-		Names: drouter.NewStringSet(names...),
+		Names: stringset.NewStringSet(names...),
 	}
 	return cmd
 }

--- a/command_test.go
+++ b/command_test.go
@@ -1,21 +1,16 @@
-package drouter_test
+package drouter
 
 import (
-	"github.com/NyanKiyoshi/disgord-plugin-router"
-	"github.com/NyanKiyoshi/disgord-plugin-router/internal/stringset"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
 
-func createDummyCommand(names ...string) *drouter.Command {
+func createDummyCommand(names ...string) command {
 	if len(names) < 1 {
 		names = []string{"test"}
 	}
 
-	cmd := &drouter.Command{
-		Names: stringset.NewStringSet(names...),
-	}
-	return cmd
+	return newCommand(names...)
 }
 
 func TestCommand_Match(t *testing.T) {
@@ -57,7 +52,7 @@ func TestCommand_MatchRE(t *testing.T) {
 func TestCommand_Handler(t *testing.T) {
 	// Create a testing command and a dummy handler
 	cmd := createDummyCommand()
-	handler := func(ctx *drouter.Context) error {
+	handler := func(ctx *Context) error {
 		return successError
 	}
 
@@ -77,7 +72,7 @@ func TestCommand_Use(t *testing.T) {
 	cmd := createDummyCommand()
 
 	// Create the dummy callback
-	callback := func(ctx *drouter.Context) error {
+	callback := func(ctx *Context) error {
 		return successError
 	}
 

--- a/context.go
+++ b/context.go
@@ -10,8 +10,8 @@ type Context struct {
 	// Session contains the received discord session
 	Session routerSession
 
-	// Command is the matched command
-	Command *Command
+	// command is the matched command
+	Command *command
 
 	// MatchedPrefix is the command (plugin's) prefix
 	MatchedPrefix string

--- a/context_test.go
+++ b/context_test.go
@@ -2,6 +2,7 @@ package drouter_test
 
 import (
 	"github.com/NyanKiyoshi/disgord-plugin-router"
+	"github.com/NyanKiyoshi/disgord-plugin-router/internal/mockdisgord"
 	"github.com/NyanKiyoshi/disgord-plugin-router/mocks/mocked_disgord"
 	"github.com/andersfylling/disgord"
 	"github.com/golang/mock/gomock"
@@ -9,22 +10,9 @@ import (
 	"testing"
 )
 
-var channelID = disgord.NewSnowflake(123)
-var selfUserID = disgord.NewSnowflake(456)
-
-func createDummyMessage() *disgord.Message {
-	return &disgord.Message{
-		ChannelID: channelID,
-		Author: &disgord.User{
-			ID: selfUserID,
-		},
-		Content: "hello",
-	}
-}
-
 func createDummyContext(session *mocked_disgord.MockrouterSession) *drouter.Context {
 	return &drouter.Context{
-		Message: createDummyMessage(),
+		Message: mockdisgord.CreateDummyMessage(),
 		Session: session,
 	}
 }
@@ -38,7 +26,7 @@ func TestContext_Say(t *testing.T) {
 	mockedSession := mocked_disgord.NewMockrouterSession(mockCtrl)
 	mockedSession.
 		EXPECT().
-		SendMsgString(channelID, messageToSend).
+		SendMsgString(mockdisgord.ChannelID, messageToSend).
 		Return(nil, nil)
 
 	ctx := createDummyContext(mockedSession)
@@ -54,7 +42,7 @@ func TestContext_SayComplex(t *testing.T) {
 	mockedSession := mocked_disgord.NewMockrouterSession(mockCtrl)
 	mockedSession.
 		EXPECT().
-		SendMsg(channelID, messageToSend).
+		SendMsg(mockdisgord.ChannelID, messageToSend).
 		Return(nil, nil)
 
 	ctx := createDummyContext(mockedSession)

--- a/dispatcher.go
+++ b/dispatcher.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 )
 
-func findPluginCommand(plugin *Plugin, receivedCommand string) *Command {
+func findPluginCommand(plugin *Plugin, receivedCommand string) *command {
 	for _, cmdObj := range plugin.Commands {
 		if cmdObj.IsMatching(receivedCommand) {
 			return cmdObj
@@ -17,7 +17,7 @@ func findPluginCommand(plugin *Plugin, receivedCommand string) *Command {
 
 // Find looks for a matching command. Returns the
 // matched prefix and command, if found.
-func (router *RouterDefinition) Find(args ...string) (string, *Command) {
+func (router *RouterDefinition) Find(args ...string) (string, *command) {
 	argCount := len(args)
 
 	if argCount < 1 {
@@ -65,14 +65,14 @@ func (router *RouterDefinition) Find(args ...string) (string, *Command) {
 	return "", nil
 }
 
-// DispatchMessage dispatches a command from a context
+// dispatchMessage dispatches a command from a context
 // to the command wrappers and then, if it was succeeded,
 // it invokes the command itself.
 //
 // Otherwise or if any error from the command, it sends the error
 // to the user as reply. Or if the bot is not able to
 // (e.g.: don't have the 'Send Message' permission), it logs the error.
-func DispatchMessage(ctx *Context, success chan bool) {
+func dispatchMessage(ctx *Context, success chan bool) {
 	var err error
 
 	// Run wrappers
@@ -111,10 +111,10 @@ func DispatchMessage(ctx *Context, success chan bool) {
 	success <- false
 }
 
-// ParseMessage parses a message into a list of arguments.
+// parseMessage parses a message into a list of arguments.
 //
 // TODO: in a future release it will parse using typing
 //  	 and allow quoted arguments.
-func ParseMessage(message string) []string {
+func parseMessage(message string) []string {
 	return strings.Fields(message)
 }

--- a/dispatcher.go
+++ b/dispatcher.go
@@ -29,7 +29,7 @@ func (router *RouterDefinition) Find(args ...string) (string, *Command) {
 
 	for _, plugin := range router.Plugins {
 		// Skip plugins that are not active
-		if !plugin.IsReady {
+		if !plugin.IsLoaded {
 			continue
 		}
 

--- a/dispatcher_test.go
+++ b/dispatcher_test.go
@@ -49,8 +49,8 @@ func TestRouterDefinition_Find(t *testing.T) {
 	plugin.Command("red")
 	subCommand := plugin.Command("blue")
 
-	// Enable the plugin
-	plugin.Activate()
+	// Manually force the plugin to be flagged as loaded
+	plugin.IsLoaded = true
 
 	for _, tt := range routerDefinitionFindTests {
 		t.Run(fmt.Sprintf("%s: %s", tt.name, tt.in), func(t *testing.T) {

--- a/errors_test.go
+++ b/errors_test.go
@@ -1,4 +1,4 @@
-package drouter_test
+package drouter
 
 import "errors"
 

--- a/events.go
+++ b/events.go
@@ -6,23 +6,23 @@ import (
 
 type callbackFunc func(ctx *Context) error
 
-// OnMessageReceived is invoked whenever a new message is created,
+// onMessageReceived is invoked whenever a new message is created,
 // it will dispatch instructions if the message is a command,
 // and if the message is not from the bot itself.
-func (router *RouterDefinition) OnMessageReceived(session disgord.Session, event *disgord.MessageCreate) {
+func (router *RouterDefinition) onMessageReceived(session disgord.Session, event *disgord.MessageCreate) {
 	myself, err := session.Myself()
 	if err != nil || event.Message.Author.ID == myself.ID {
 		return
 	}
 
-	args := ParseMessage(event.Message.Content)
+	args := parseMessage(event.Message.Content)
 	matchedPrefix, foundCommand := router.Find(args...)
 
 	if foundCommand == nil {
 		return
 	}
 
-	go DispatchMessage(&Context{
+	go dispatchMessage(&Context{
 		Session:       session,
 		Message:       event.Message,
 		Command:       foundCommand,

--- a/events_test.go
+++ b/events_test.go
@@ -57,11 +57,14 @@ func TestRouterDefinition_OnMessageReceived_HandlesErrors(t *testing.T) {
 		// Will contain whether the ping command was invoked or not
 		var pingHandlerWasCalled bool
 
-		// Create a !ping module
-		router.Plugin(_myModuleInternalType{}, "ping").Handler(func(ctx *drouter.Context) error {
+		// Create a !ping plugn
+		pingPlugin := router.Plugin(_myModuleInternalType{}, "ping").Handler(func(ctx *drouter.Context) error {
 			pingHandlerWasCalled = true
 			return nil
-		}).SetPrefix("!").Activate()
+		}).SetPrefix("!")
+
+		// Force the plugin to be flagged as loaded
+		pingPlugin.IsLoaded = true
 
 		// Create a valid command message
 		message := createDummyMessage()

--- a/events_test.go
+++ b/events_test.go
@@ -1,6 +1,6 @@
 //+build ignore
 
-package drouter_test
+package drouter
 
 import (
 	"github.com/NyanKiyoshi/disgord-plugin-router"
@@ -33,12 +33,12 @@ func mockMySelf(
 // - That it's ignoring messages that are the bot itself (returning nil).
 // - And that it returns nil when the command is not found.
 func TestRouterDefinition_OnMessageReceived_HandlesErrors(t *testing.T) {
-	router := createTestRouter()
+	router := drouter.RouterDefinition{}
 
 	t.Run("ignores self messages", func(t *testing.T) {
 		mockMySelf(t, selfUserID, func(t *testing.T, session *mocked_disgord.MockrouterSession) {
 			// It should return nil
-			assert.Nil(t, router.OnMessageReceived(session, &disgord.MessageCreate{
+			assert.Nil(t, router.onMessageReceived(session, &disgord.MessageCreate{
 				Message: createDummyMessage(),
 			}))
 		})
@@ -47,7 +47,7 @@ func TestRouterDefinition_OnMessageReceived_HandlesErrors(t *testing.T) {
 	t.Run("returns nil when invalid command", func(t *testing.T) {
 		mockMySelf(t, disgord.Snowflake(555), func(t *testing.T, session *mocked_disgord.MockrouterSession) {
 			// It should return nil
-			assert.Nil(t, router.OnMessageReceived(session, &disgord.MessageCreate{
+			assert.Nil(t, router.onMessageReceived(session, &disgord.MessageCreate{
 				Message: createDummyMessage(),
 			}))
 		})
@@ -72,7 +72,7 @@ func TestRouterDefinition_OnMessageReceived_HandlesErrors(t *testing.T) {
 
 		mockMySelf(t, disgord.Snowflake(555), func(t *testing.T, session *mocked_disgord.MockrouterSession) {
 			// Dispatch the event
-			successChannel := router.OnMessageReceived(session, &disgord.MessageCreate{
+			successChannel := router.onMessageReceived(session, &disgord.MessageCreate{
 				Message: message,
 			})
 

--- a/internal/mockdisgord/messages.go
+++ b/internal/mockdisgord/messages.go
@@ -2,9 +2,13 @@ package mockdisgord
 
 import "github.com/andersfylling/disgord"
 
+// ChannelID represents a dummy message's ChannelID
 var ChannelID = disgord.NewSnowflake(123)
+
+// SelfUserID represents a dummy message's author ID
 var SelfUserID = disgord.NewSnowflake(456)
 
+// CreateDummyMessage creates a disgord test message.
 func CreateDummyMessage() *disgord.Message {
 	return &disgord.Message{
 		ChannelID: ChannelID,

--- a/internal/mockdisgord/messages.go
+++ b/internal/mockdisgord/messages.go
@@ -1,0 +1,16 @@
+package mockdisgord
+
+import "github.com/andersfylling/disgord"
+
+var ChannelID = disgord.NewSnowflake(123)
+var SelfUserID = disgord.NewSnowflake(456)
+
+func CreateDummyMessage() *disgord.Message {
+	return &disgord.Message{
+		ChannelID: ChannelID,
+		Author: &disgord.User{
+			ID: SelfUserID,
+		},
+		Content: "hello",
+	}
+}

--- a/internal/stringset/stringset.go
+++ b/internal/stringset/stringset.go
@@ -1,4 +1,4 @@
-// stringset package was taken from docker's distribution repo, under Apache-2.0 license:
+// Package stringset was taken from docker's distribution repo, under Apache-2.0 license:
 // https://github.com/docker/distribution/blob/0d3efadf015/registry/auth/token/stringset.go
 // Thank you for your work! <3
 package stringset

--- a/internal/stringset/stringset.go
+++ b/internal/stringset/stringset.go
@@ -1,7 +1,7 @@
-// Package drouter was taken from docker's distribution repo, under Apache-2.0 license:
+// stringset package was taken from docker's distribution repo, under Apache-2.0 license:
 // https://github.com/docker/distribution/blob/0d3efadf015/registry/auth/token/stringset.go
 // Thank you for your work! <3
-package drouter
+package stringset
 
 // StringSet is a useful type for looking up strings.
 type StringSet map[string]struct{}

--- a/plugin.go
+++ b/plugin.go
@@ -21,8 +21,8 @@ type Plugin struct {
 	// Wrappers Contains the registered sub-commands of the plugin.
 	Commands []*Command
 
-	// IsReady is true is the module was loaded and installed into the client.
-	IsReady bool
+	// IsLoaded is true is the module was loaded and installed into the client.
+	IsLoaded bool
 }
 
 // Use appends given callbacks to a plugin to call
@@ -75,8 +75,8 @@ func (plugin *Plugin) Help(helpText string) *Plugin {
 	return plugin
 }
 
-// Activate marks a plugin as ready.
-func (plugin *Plugin) Activate() {
+// activate marks a plugin as ready.
+func (plugin *Plugin) activate() {
 	// TODO: we should dispatch setUp(...)
-	plugin.IsReady = true
+	plugin.IsLoaded = true
 }

--- a/plugin.go
+++ b/plugin.go
@@ -12,14 +12,14 @@ type Plugin struct {
 	Prefix string
 
 	// RootCommand defines the base plugin's root/ base command
-	RootCommand Command
+	RootCommand command
 
 	// Listeners defines the different event handlers
 	// of the plugin (see https://godoc.org/github.com/andersfylling/disgord/event).
 	Listeners map[string][]interface{}
 
 	// Wrappers Contains the registered sub-commands of the plugin.
-	Commands []*Command
+	Commands []*command
 
 	// IsLoaded is true is the module was loaded and installed into the client.
 	IsLoaded bool
@@ -28,7 +28,7 @@ type Plugin struct {
 // Use appends given callbacks to a plugin to call
 // whenever a command is being invoked.
 func (plugin *Plugin) Use(callbackFuncs ...callbackFunc) *Plugin {
-	// FIXME: we should put them as global wrappers in Plugin
+	// FIXME: we should put them as global wrappers in plugin
 	//        instead of the root command.
 	plugin.RootCommand.Use(callbackFuncs...)
 	return plugin
@@ -60,11 +60,11 @@ func (plugin *Plugin) On(eventName string, inputs ...interface{}) *Plugin {
 	return plugin
 }
 
-// Command creates a new sub-command for the plugin.
-func (plugin *Plugin) Command(names ...string) *Command {
-	command := newCommand(names...)
-	plugin.Commands = append(plugin.Commands, &command)
-	return &command
+// command creates a new sub-command for the plugin.
+func (plugin *Plugin) Command(names ...string) *command {
+	createdCommand := newCommand(names...)
+	plugin.Commands = append(plugin.Commands, &createdCommand)
+	return &createdCommand
 }
 
 // Help sets the help text of a command. The first line is

--- a/plugin.go
+++ b/plugin.go
@@ -62,11 +62,9 @@ func (plugin *Plugin) On(eventName string, inputs ...interface{}) *Plugin {
 
 // Command creates a new sub-command for the plugin.
 func (plugin *Plugin) Command(names ...string) *Command {
-	newCommand := &Command{
-		Names: NewStringSet(names...),
-	}
-	plugin.Commands = append(plugin.Commands, newCommand)
-	return newCommand
+	command := newCommand(names...)
+	plugin.Commands = append(plugin.Commands, &command)
+	return &command
 }
 
 // Help sets the help text of a command. The first line is

--- a/plugin.go
+++ b/plugin.go
@@ -60,7 +60,7 @@ func (plugin *Plugin) On(eventName string, inputs ...interface{}) *Plugin {
 	return plugin
 }
 
-// command creates a new sub-command for the plugin.
+// Command creates a new sub-command for the plugin.
 func (plugin *Plugin) Command(names ...string) *command {
 	createdCommand := newCommand(names...)
 	plugin.Commands = append(plugin.Commands, &createdCommand)

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -1,18 +1,25 @@
 package drouter_test
 
 import (
+	"errors"
 	"github.com/NyanKiyoshi/disgord-plugin-router"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
 
+func createTestPlugin() *drouter.Plugin {
+	router := drouter.RouterDefinition{}
+	return router.Plugin(struct{}{}, "my-module")
+}
+
 func TestPlugin_Use(t *testing.T) {
-	// Create a testing plugin
+	// Create a testing plugin and a dummy error
 	plugin := createTestPlugin()
+	dummyError := errors.New("test")
 
 	// Create the dummy callback
 	callback := func(ctx *drouter.Context) error {
-		return successError
+		return dummyError
 	}
 
 	// Ensure there are not wrappers on an empty plugin
@@ -23,7 +30,7 @@ func TestPlugin_Use(t *testing.T) {
 
 	// Ensure it was added
 	assert.Len(t, plugin.RootCommand.Wrappers, 1)
-	assert.Equal(t, successError, plugin.RootCommand.Wrappers[0](nil))
+	assert.Equal(t, dummyError, plugin.RootCommand.Wrappers[0](nil))
 }
 
 func TestPlugin_SetPrefix(t *testing.T) {
@@ -41,10 +48,11 @@ func TestPlugin_SetPrefix(t *testing.T) {
 }
 
 func TestPlugin_Handler(t *testing.T) {
-	// Create a testing plugin and a dummy handler
+	// Create a testing plugin, a dummy error and an handler
 	plugin := createTestPlugin()
+	dummyError := errors.New("test")
 	handler := func(ctx *drouter.Context) error {
-		return successError
+		return dummyError
 	}
 
 	// Ensure no handler is registered by default
@@ -55,7 +63,7 @@ func TestPlugin_Handler(t *testing.T) {
 
 	// Check it was correctly set
 	assert.NotNil(t, plugin.RootCommand.HandlerFunc)
-	assert.Equal(t, successError, plugin.RootCommand.HandlerFunc(nil))
+	assert.Equal(t, dummyError, plugin.RootCommand.HandlerFunc(nil))
 }
 
 func TestPlugin_On(t *testing.T) {
@@ -107,7 +115,8 @@ func TestPlugin_Command(t *testing.T) {
 	cmd := plugin.Command("color", "colour")
 
 	// Check if the command was correctly registered
-	assert.EqualValues(t, []*drouter.Command{cmd}, plugin.Commands)
+	assert.Len(t, plugin.Commands, 1)
+	assert.Equal(t, cmd, plugin.Commands[0])
 
 	// Check if the registered command is correct
 	assert.ElementsMatch(t, []string{"color", "colour"}, cmd.Names.Keys())

--- a/router.go
+++ b/router.go
@@ -95,7 +95,7 @@ func (router *RouterDefinition) Configure(client routerClient) {
 // installInternalEvents installs the router internal events
 // into a given client.
 func (router *RouterDefinition) installInternalEvents(client routerClient) {
-	if err := client.On(event.MessageCreate, router.OnMessageReceived); err != nil {
+	if err := client.On(event.MessageCreate, router.onMessageReceived); err != nil {
 		LogFatalf("failed to register router's internal MessageCreate event: %s", err)
 	}
 }

--- a/router.go
+++ b/router.go
@@ -37,12 +37,10 @@ var Router = &RouterDefinition{}
 //     name         The plugin's human readable name, such as "bot-statistics".
 func (router *RouterDefinition) Plugin(pluginType interface{}, names ...string) *Plugin {
 	newPlugin := &Plugin{
-		ImportName: reflect.TypeOf(pluginType).PkgPath(),
-		RootCommand: Command{
-			Names: NewStringSet(names...),
-		},
-		Prefix:    DefaultPrefix,
-		Listeners: map[string][]interface{}{},
+		ImportName:  reflect.TypeOf(pluginType).PkgPath(),
+		RootCommand: newCommand(names...),
+		Prefix:      DefaultPrefix,
+		Listeners:   map[string][]interface{}{},
 	}
 
 	router.Plugins = append(router.Plugins, newPlugin)

--- a/router.go
+++ b/router.go
@@ -111,5 +111,5 @@ func configurePlugin(plugin *Plugin, client routerClient) {
 	}
 
 	// Set the module as ready and enabled
-	plugin.Activate()
+	plugin.activate()
 }

--- a/router_test.go
+++ b/router_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/NyanKiyoshi/disgord-plugin-router/mocks/mocked_disgord"
 	"github.com/andersfylling/disgord"
 	"github.com/golang/mock/gomock"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
@@ -16,11 +17,7 @@ func createTestRouter() *drouter.RouterDefinition {
 	return &drouter.RouterDefinition{}
 }
 
-func createTestPlugin() *drouter.Plugin {
-	return createTestRouter().Plugin(_myModuleInternalType{}, "my-module")
-}
-
-func ExampleNew_newPlugin() {
+func Example_newPlugin() {
 	myPlugin := drouter.Router.Plugin(_myModuleInternalType{}, "my-plugin")
 	fmt.Printf("ImportName: %s\nNames: %s", myPlugin.ImportName, myPlugin.RootCommand.Names.Keys())
 	// Output:
@@ -112,7 +109,7 @@ func TestRouterDefinition_Configure_OnlyInstallInternalEvents(t *testing.T) {
 		if customErr != nil {
 			assert.Equal(
 				subT,
-				"failed to register router's internal MessageCreate event: success",
+				"failed to register router's internal MessageCreate event: successful test",
 				receivedLog,
 			)
 		}
@@ -123,7 +120,7 @@ func TestRouterDefinition_Configure_OnlyInstallInternalEvents(t *testing.T) {
 	})
 
 	t.Run("with errored configuration", func(t *testing.T) {
-		runTest(t, successError)
+		runTest(t, errors.New("successful test"))
 	})
 }
 
@@ -171,7 +168,7 @@ func TestRouterDefinition_Configure_WithRegisteredPlugins(t *testing.T) {
 			assert.Equal(
 				subT,
 				"failed to register event MESSAGE_CREATE "+
-					"for plugin github.com/NyanKiyoshi/disgord-plugin-router_test: success",
+					"for plugin github.com/NyanKiyoshi/disgord-plugin-router_test: successful test",
 				receivedLog,
 			)
 		}
@@ -182,6 +179,6 @@ func TestRouterDefinition_Configure_WithRegisteredPlugins(t *testing.T) {
 	})
 
 	t.Run("with invalid event error", func(t *testing.T) {
-		runTest(t, successError)
+		runTest(t, errors.New("successful test"))
 	})
 }

--- a/router_test.go
+++ b/router_test.go
@@ -140,7 +140,7 @@ func TestRouterDefinition_Configure_WithRegisteredPlugins(t *testing.T) {
 	disabledPlugin := router.Plugin(_myModuleInternalType{}).SetPrefix("disabled")
 
 	// Ensure it is false by default
-	assert.False(t, plugin.IsReady)
+	assert.False(t, plugin.IsLoaded)
 
 	runTest := func(subT *testing.T, customErr error) {
 		// Mock log.Fatal
@@ -163,8 +163,8 @@ func TestRouterDefinition_Configure_WithRegisteredPlugins(t *testing.T) {
 		router.Configure(mockedClient)
 
 		// Ensure the plugin was enabled and the disabled one was ignore
-		assert.True(t, plugin.IsReady)
-		assert.False(t, disabledPlugin.IsReady)
+		assert.True(t, plugin.IsLoaded)
+		assert.False(t, disabledPlugin.IsLoaded)
 
 		// Check if log.Fatal was called if an error was set
 		if customErr != nil {


### PR DESCRIPTION
This pull request is attempting to reduce the `discord-plugin-router` public API into a smaller footprint, and thus, move some tests back into the main package instead of a excluded test package.

- `drouter_test` is now only for public API;
- `drouter` tests are mostly testing private API.

This PR is unexporting:
- The `Command` struct (-> `drouter.command`);
- The `Plugin.Activate()` method, it should only be used internally;

This PR is refactoring:
- The `Plugin.IsReady` into `Plugin.IsLoaded`;
- Moving `stringset` into its own internal package;
- Moved the command creation (from the struct) into a constructor to improve its usage and prevent user errors.